### PR TITLE
Feat/signup and signin buttons

### DIFF
--- a/Contributing/README.md
+++ b/Contributing/README.md
@@ -84,3 +84,10 @@ Welcome to the FarmRuler project! We appreciate your contributions. Please add y
 - **GitHub:** [GitHub Profile](https://github.com/abhishek332)
 - **LinkedIn:** [LinkedIn Profile](https://www.linkedin.com/in/abhishek-porwal-213726194/)
 - **Info:** Frontend Developer with expertise in React.js, TypeScript, and the MERN stack. Specializes in building scalable web applications, optimizing performance, and delivering user-centric solutions. Experienced in using Next.js, Tailwind CSS, and WebSockets, with a focus on security and interactive dashboards..
+
+### <img src="https://avatars.githubusercontent.com/u/104073199" alt="Photo" width="120" height="120" style="border-radius: 50%;">
+**Name:** [Aditya Pratap Singh](https://github.com/Aditya-PS-05)
+
+- **GitHub:** [GitHub Profile](https://github.com/Aditya-PS-05)
+- **LinkedIn:** [LinkedIn Profile](https://www.linkedin.com/in/aditya-pratap-singh-952a8820a/)
+- **Info:** Full stack developer and blockchain developer

--- a/app/page.js
+++ b/app/page.js
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import Footer from "./components/Footer";
 import Navbar from "./components/Navbar";
 import ThemeToggle from "./components/ThemeToggle";

--- a/app/page.js
+++ b/app/page.js
@@ -50,12 +50,12 @@ export default function Home() {
       </section>
 
       <section className="bg-green-500 text-center py-6 mt-auto border-t-4 border-gray-300 rounded-lg">
-        <button className="mx-2 px-6 py-2 font-semibold rounded-lg shadow-md hover:bg-gray-100">
+        <Link className="mx-2 px-6 py-2 font-semibold rounded-lg shadow-md hover:bg-gray-100" href='/sign-up'>
           Sign Up
-        </button>
-        <button className="mx-2 px-6 py-2 bg-white text-green-500 font-semibold rounded-lg shadow-md hover:bg-gray-100">
+        </Link>
+        <Link className="mx-2 px-6 py-2 bg-white text-green-500 font-semibold rounded-lg shadow-md hover:bg-gray-100" href='/sign-in'>
           Sign In
-        </button>
+        </Link>
       </section>
 
       <Footer />


### PR DESCRIPTION
closes #41 

## Summary
Changed `Button` to `Link` to add the href property for the navigation to the `sign-in` and `sign-up` pages.